### PR TITLE
Clean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,6 @@
 FROM kbase/kb-sdk:1.2.1
 
-# Update 14.04 to 16.04
-RUN apt update || echo
-RUN apt upgrade -y --force-yes || echo
-RUN apt install -y update-manager-core
-RUN do-release-upgrade -f DistUpgradeViewNonInteractive
-
-# Update 16.04 to 18.04
-RUN apt update || echo
-RUN apt upgrade -y --force-yes || echo
-RUN do-release-upgrade -f DistUpgradeViewNonInteractive
-
-# Update 18.04 to 20.04
-RUN apt update || echo
-RUN apt upgrade -y --force-yes || echo
-RUN do-release-upgrade -f DistUpgradeViewNonInteractive
-RUN apt remove -y usrmerge
-
-# Update 20.04 to 22.04
-RUN apt update
-RUN apt upgrade -y \
-    --allow-downgrades \
-    --allow-remove-essential \
-    --allow-change-held-packages
-RUN do-release-upgrade -f DistUpgradeViewNonInteractive || test $? -eq 1
-RUN apt remove -y usrmerge
-
-# Install latest docker
-RUN for pkg in docker.io docker-doc docker-compose docker-compose-v2 \
-    podman-docker containerd runc; do sudo apt-get remove $pkg; done
-RUN apt install -y curl
-RUN apt autoremove -y
-RUN curl -fsSL https://get.docker.com | sh
-RUN mkdir /.docker && chmod 777 /.docker
+COPY update.sh /update.sh
+RUN /update.sh
+RUN rm -rf /tmp /boot && mkdir /tmp && mkdir /boot
+RUN chmod 777 /.docker /boot /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,3 @@ FROM kbase/kb-sdk:1.2.1
 
 COPY update.sh /update.sh
 RUN /update.sh
-RUN rm -rf /tmp /boot && mkdir /tmp && mkdir /boot
-RUN chmod 777 /.docker /boot /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,6 @@ RUN apt remove -y usrmerge
 RUN for pkg in docker.io docker-doc docker-compose docker-compose-v2 \
     podman-docker containerd runc; do sudo apt-get remove $pkg; done
 RUN apt install -y curl
+RUN apt autoremove -y
 RUN curl -fsSL https://get.docker.com | sh
 RUN mkdir /.docker && chmod 777 /.docker

--- a/update.sh
+++ b/update.sh
@@ -32,5 +32,30 @@ for pkg in docker.io docker-doc docker-compose docker-compose-v2 \
 apt install -y curl
 apt autoremove -y
 curl -fsSL https://get.docker.com | sh
+apt remove -y $(dpkg-query --show 'linux-modules-*' | cut -f1 | grep -v "$(uname -r)")
+rm -rf \
+    /tmp \
+    /boot \
+    /usr/lib/firmware \
+    /usr/lib/jvm/java-8-openjdk-amd64 \
+    /usr/share/doc \
+    /usr/share/man
+find /usr/share/locale \
+    -mindepth 1 -maxdepth 1 \
+    -not -name en \
+    -execdir rm -rf {} +
 mkdir /.docker
-chmod 777 /.docker
+mkdir /tmp
+mkdir /boot
+mkdir -p /usr/lib/firmware
+mkdir -p /usr/lib/jvm/java-8-openjdk-amd64
+mkdir -p /usr/share/doc
+mkdir -p /usr/share/man
+chmod 777 \
+    /.docker \
+    /boot \
+    /tmp \
+    /usr/lib/firmware \
+    /usr/lib/jvm/java-8-openjdk-amd64 \
+    /usr/share/doc \
+    /usr/share/man

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Update 14.04 to 16.04
+apt update || echo
+apt upgrade -y --force-yes || echo
+apt install -y update-manager-core
+do-release-upgrade -f DistUpgradeViewNonInteractive
+
+# Update 16.04 to 18.04
+apt update || echo
+apt upgrade -y --force-yes || echo
+do-release-upgrade -f DistUpgradeViewNonInteractive
+
+# Update 18.04 to 20.04
+apt update || echo
+apt upgrade -y --force-yes || echo
+do-release-upgrade -f DistUpgradeViewNonInteractive
+apt remove -y usrmerge
+
+# Update 20.04 to 22.04
+apt update
+apt upgrade -y \
+    --allow-downgrades \
+    --allow-remove-essential \
+    --allow-change-held-packages
+do-release-upgrade -f DistUpgradeViewNonInteractive || test $? -eq 1
+apt remove -y usrmerge
+
+# Install latest docker
+for pkg in docker.io docker-doc docker-compose docker-compose-v2 \
+    podman-docker containerd runc; do sudo apt-get remove $pkg; done
+apt install -y curl
+apt autoremove -y
+curl -fsSL https://get.docker.com | sh
+mkdir /.docker
+chmod 777 /.docker


### PR DESCRIPTION
This PR reduces the image size to make it less likely that GitHub runners run out of disk space (14 GB [by default](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)) when running `kb_sdk test`.